### PR TITLE
chore: fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://SciML.github.io/ModelingToolkitNeuralNets.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://SciML.github.io/ModelingToolkitNeuralNets.jl/dev/)
-[![Build Status](https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/workflows/Tests.yml/badge.svg?branch=main)](https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/workflows/Tests.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/SciML/ModelingToolkitNeuralNets.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/SciML/ModelingToolkitNeuralNets.jl)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)


### PR DESCRIPTION
Workflow file was changed from CI.yml to Tests.yml in https://github.com/SciML/ModelingToolkitNeuralNets.jl/pull/27