### PR TITLE
docs: use output of the neural network for plotting

### DIFF
--- a/docs/src/friction.md
+++ b/docs/src/friction.md
@@ -151,7 +151,7 @@ res_p = SciMLStructures.replace(Tunable(), prob.p, res)
 res_prob = remake(prob, p = res_p)
 res_sol = solve(res_prob, Rodas4(), saveat = sol_ref.t)
 @test first.(sol_ref.u)≈first.(res_sol.u) rtol=1e-3 #hide
-@test friction.(first.(sol_ref.u))≈(Fu .- first.(res_sol(res_sol.t, Val{1}).u)) rtol=1e-1 #hide
+@test friction.(first.(sol_ref.u))≈(getindex.(res_sol[sys.nn.output.u], 1)) rtol=1e-1 #hide
 nothing #hide
 ```
 
@@ -173,7 +173,7 @@ It matches the data well! Let's also check the predictions for the friction forc
 
 ```@example friction
 scatter(sol_ref.t, friction.(first.(sol_ref.u)), label = "ground truth friction")
-plot!(res_sol.t, Fu .- first.(res_sol(res_sol.t, Val{1}).u),
+plot!(res_sol.t, getindex.(res_sol[sys.nn.output.u], 1),
     label = "friction from neural network")
 ```
 


### PR DESCRIPTION
This fits the data correctly.

![image](https://github.com/SciML/ModelingToolkitNeuralNets.jl/assets/35105271/2d153df3-4e1b-4df4-97bf-8765990ece2d)

using solution to get the derivatives give slightly different results (I guess it might be because of splines):

![image](https://github.com/SciML/ModelingToolkitNeuralNets.jl/assets/35105271/93e63be1-3458-4bc2-9721-93d0611215ef)

