### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitNeuralNets"
 uuid = "f162e290-f571-43a6-83d9-22ecc16da15f"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Version Bump

Bumping version from 2.2.0 to 2.3.0 to prepare for release.

### Changes since last release (v2.2.0)
- CompatHelper: bump compat for JET in [extras] to 0.11
- CompatHelper: bump compat for ModelingToolkit to 11
- Bump actions/checkout from 4 to 6
- Cleanup and test dependencies consolidation
- Add scalar dispatch for SymbolicNeuralNetwork (PR #84)

### Registration Command

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)