### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized caller workflows to bring the repo up to the full standard set:

- Runic Suggestions (`RunicSuggestions.yml`) — auto-format suggestions on PRs
- Dependabot Auto-merge (`DependabotAutoMerge.yml`)

(Doc Preview Cleanup already present as `DocsPreviewCleanup.yml`, so not duplicated.)

These are static caller files referencing `SciML/.github` reusable workflows at `@v1`. No existing workflows, `Project.toml`, or source files were modified.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)