### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,10 +17,9 @@ jobs:
       matrix:
         group:
           - Core
-        julia-version: ['1.10']
+        julia-version: ['lts']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
       group: "${{ matrix.group }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,31 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
-    inputs:
-      lookback:
-        default: 3
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup:
- TagBot.yml: replaced inlined JuliaRegistries/TagBot with the canonical SciML thin caller (tagbot.yml@v1).
- Downgrade.yml: changed the matrix julia-version floor 1.10 -> lts; dropped the stdlib skip (Pkg, TOML).
- .typos.toml already present; no SpellCheck change needed.

Ignore until reviewed by @ChrisRackauckas.