### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,19 +20,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,9 @@
+# Root test-group matrix for ModelingToolkitNeuralNets.jl, consumed by the
+# canonical grouped-tests.yml@v1 caller. The single "All" group reproduces the
+# previous Tests.yml matrix: the full suite (QA + functional tests, dispatched
+# via GROUP=All in test/runtests.jl) on Julia "1" and "lts", across all three
+# OSes. runtests.jl runs QA whenever GROUP != "Core", so GROUP=All runs
+# everything in one job per cell, matching the old behavior exactly.
+[All]
+versions = ["1", "lts"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
## Summary

Converts the root test workflow (`Tests.yml`) into a thin caller of the canonical SciML reusable `grouped-tests.yml@v1`, with the test matrix declared once in a root `test/test_groups.toml`.

**Before:** `Tests.yml` hand-maintained a `version × os` matrix (`{1, lts} × {ubuntu, macos, windows}` = 6 cells) and called `tests.yml@v1` directly.

**After:**
- `Tests.yml` `jobs.tests` is now just:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
- `test/test_groups.toml` declares a single `All` group:
  ```toml
  [All]
  versions = ["1", "lts"]
  os = ["ubuntu-latest", "macos-latest", "windows-latest"]
  ```

The `name: "Tests"`, `on:` triggers, and `concurrency:` block are preserved verbatim, so the existing branch-protection status check is unchanged. No `with:` inputs are needed — all of group-env-name (`GROUP`), check-bounds (`yes`), coverage (`true`), coverage-directories (`src,ext`), and apt-packages match the reusable workflow defaults and the old job's behavior.

## Why a single `All` group

This repo's `test/runtests.jl` dispatches with `const GROUP = get(ENV, "GROUP", "All")` and runs QA whenever `GROUP != "Core"`; the functional testsets always run. The old `Tests.yml` never set `GROUP`, so every cell ran the full suite (QA + functional) under the default `All`. A single `All` group reproduces that exactly: `GROUP=All` → QA + all functional tests in one job per cell. `runtests.jl` is **unchanged**; QA is not isolated in this repo's dispatch, so a Core/QA split would either drop QA (Core excludes it) or duplicate the functional tests, neither of which reproduces the old matrix.

## Matrix match

Verified with `scripts/compute_affected_sublibraries.jl . --root-matrix` (from `SciML/.github@v1`). Emitted set:

| group | version | os |
|-------|---------|----|
| All | 1 | ubuntu-latest |
| All | 1 | macos-latest |
| All | 1 | windows-latest |
| All | lts | ubuntu-latest |
| All | lts | macos-latest |
| All | lts | windows-latest |

**6/6 exact** on (version, os), each cell running the identical full suite as before.

## QA

QA (Aqua + JET) already exists in `test/qa.jl` and runs under this matrix as before. Per Category A, no local Aqua/JET run was performed and `runtests.jl` was not modified. `Project.toml` metadata was checked statically: `julia` compat floor is already `"1.10"` (LTS), every `[targets].test` entry is declared in `[extras]`, every dep/extra has a `[compat]` entry, and there are no stale extras — no benign-metadata fixes were needed.

YAML and TOML both parse cleanly (static-verified).

Ignore until reviewed by @ChrisRackauckas.