### PR TITLE
docs: use SciMLLogging.None() instead of verbose=false (OrdinaryDiffEq v7)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,6 +12,7 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -19,9 +20,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
-[sources.ModelingToolkitNeuralNets]
-path = ".."
 
 [compat]
 Documenter = "1.3"
@@ -37,6 +35,7 @@ OrdinaryDiffEqTsit5 = "1, 2"
 OrdinaryDiffEqVerner = "1, 2"
 Plots = "1"
 SciMLBase = "2, 3"
+SciMLLogging = "2"
 SciMLSensitivity = "7"
 SciMLStructures = "1.1.0"
 StableRNGs = "1"
@@ -44,3 +43,6 @@ Statistics = "1"
 SymbolicIndexingInterface = "0.3.15"
 SymbolicRegression = "1"
 Zygote = "0.7"
+
+[sources.ModelingToolkitNeuralNets]
+path = ".."

--- a/docs/src/nnblock.md
+++ b/docs/src/nnblock.md
@@ -212,6 +212,7 @@ using OptimizationOptimJL
 using LineSearches
 using Statistics
 using SciMLSensitivity
+import SciMLLogging
 import Zygote
 
 tp = Symbolics.scalarize(sys3.thermal_nn.nn.p)
@@ -252,7 +253,7 @@ function cost(x, opt_ps)
     new_prob = remake(prob; u0, p)
 
     new_sol = solve(new_prob, Tsit5(), saveat = ts, abstol = 1e-8,
-        reltol = 1e-8, verbose = false, sensealg = GaussAdjoint())
+        reltol = 1e-8, verbose = SciMLLogging.None(), sensealg = GaussAdjoint())
 
     !SciMLBase.successful_retcode(new_sol) && return Inf
 

--- a/docs/src/symbolic_ude_tutorial.md
+++ b/docs/src/symbolic_ude_tutorial.md
@@ -20,6 +20,7 @@ Next, we simulate our model for a true parameter set (which we wish to recover).
 
 ```@example symbolic_ude
 using OrdinaryDiffEqTsit5, Plots
+import SciMLLogging
 u0 = [X => 2.0, Y => 0.1]
 ps_true = [v => 1.1, K => 2.0, n => 3.0, d => 0.5]
 sim_cond = [u0; ps_true]
@@ -75,7 +76,7 @@ We can now fit our UDE model (including the neural network and the parameter d) 
 function loss(ps, (oprob_base, set_ps, sample_t, sample_X, sample_Y))
     p = set_ps(oprob_base, ps)
     new_oprob = remake(oprob_base; p)
-    new_osol = solve(new_oprob, Tsit5(); saveat = sample_t, verbose = false)
+    new_osol = solve(new_oprob, Tsit5(); saveat = sample_t, verbose = SciMLLogging.None())
     SciMLBase.successful_retcode(new_osol) || return Inf # Simulation failed -> Inf loss.
     x_error = sum((x_sim - x_data)^2 for (x_sim, x_data) in zip(new_osol[X], sample_X))
     y_error = sum((y_sim - y_data)^2 for (y_sim, y_data) in zip(new_osol[Y], sample_Y))


### PR DESCRIPTION
## Problem

The Documentation build on `main` is red. The `@example` blocks in `docs/src/nnblock.md` and `docs/src/symbolic_ude_tutorial.md` pass `verbose = false` (a `Bool`) to `solve`. OrdinaryDiffEq v7 no longer accepts a `Bool` for `verbose`:

```
ArgumentError: Passing a `Bool` for `verbose` is no longer supported in OrdinaryDiffEq v7.
Use `DEVerbosity()` or a preset like `Standard()`, `None()`, etc. from SciMLLogging.
```

This caused `failed to run @example block` errors at `nnblock.md:208-292` and `symbolic_ude_tutorial.md:74-83`, which then cascaded into `UndefVarError`s (`new_sol1`, `opt_sol`, `oprob_fitted`) in downstream blocks and terminated the build (`[:example_block]`).

## Fix

`verbose = false` means "suppress all solver output", which maps to the `SciMLLogging.None()` preset (per DiffEqBase, `_process_verbose_param(::Val{false})` resolves to `DEVerbosity(SciMLLogging.None())`). This PR:

- Adds `SciMLLogging` (compat `"2"`) to `docs/Project.toml` (resolves to the same v2.0.0 already in the docs Manifest, no other resolution changes).
- Replaces `verbose = false` with `verbose = SciMLLogging.None()` in both tutorials, and adds `import SciMLLogging` to the relevant example modules.

## Verification (local, Julia 1.10 / docs env)

- Confirmed `solve(prob, Tsit5(); verbose = SciMLLogging.None())` returns `retcode = Success`, while `verbose = false` still throws the `ArgumentError`.
- Ran `julia --project=docs docs/make.jl`: the build now evaluates the `nnblock.md` `potplate` block (previously the first failure) **with zero `ArgumentError`/`failed to run`/`UndefVarError` markers**, and proceeds into the subsequent `new_sol1` and `equation_search` blocks. (The local run was OOM-killed at the memory-heavy SymbolicRegression block on a heavily-loaded shared machine; this is unrelated to the docs error and will not occur on CI runners.)
- Independently reproduced the `symbolic_ude_tutorial.md` `loss`-block solve call with `verbose = SciMLLogging.None()`: `retcode = Success`.

## Note

There is a separate, pre-existing, **platform-specific** failure on the `tests / All (julia lts, macos-latest)` job only: `@test res2.objective < 1.5e-4` evaluates to `0.000270... < 0.00015` on macOS aarch64 LTS. It passes on ubuntu/windows for both `lts` and `1`. This is optimizer-convergence noise (LBFGS/Adam landing in a slightly worse local minimum due to aarch64 BLAS/LAPACK differences) and is intentionally **not** touched here — loosening that tolerance would risk masking a real regression on other platforms. Out of scope for this PR.

Please ignore until reviewed by @ChrisRackauckas