### PR TITLE
Fix flaky master CI: relax knife-edge LBFGS objective bound in lotka_volterra test

### DIFF
--- a/test/lotka_volterra.jl
+++ b/test/lotka_volterra.jl
@@ -146,7 +146,14 @@ res2 = solve(op2, LBFGS(), maxiters = 5000) #, callback = plot_cb, verbose=true)
 
 display(res2.stats)
 display(res.original)
-@test res2.objective < 1.5e-4
+# The LBFGS stage terminates at MaxIters (not a gradient tolerance), so the
+# final objective depends on the exact optimizer trajectory, which varies with
+# BLAS/platform floating-point reassociation. Across CI it has been observed in
+# [~3.6e-5, ~2.8e-4] for a converged fit, with the 1.5e-4 bound landing inside
+# that jitter band and flipping pass/fail between linux/macos/windows run to
+# run. 5e-4 sits safely above the jitter band while staying ~4000x below the
+# untrained loss (O(1)), so it still verifies the UDE actually trained.
+@test res2.objective < 5.0e-4
 
 u0, p = set_x(prob, res.u)
 res_prob = remake(prob; u0, p)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

The master `tests / All (julia lts)` lane has been failing on the `Basic` testset (`test/lotka_volterra.jl:149`):

```
Basic: Test Failed at test/lotka_volterra.jl:149
  Expression: res2.objective < 0.00015
   Evaluated: 0.00028010684535790533 < 0.00015   # windows lts
   Evaluated: 0.0002385427084901909  < 0.00015   # ubuntu lts
```

This is the single failing assertion (`9 passed, 1 failed, 0 errored, 2 broken`).

## Root cause: knife-edge threshold on a MaxIters-terminated optimizer

`res2` comes from a two-stage UDE training (Adam(1e-3, maxiters=10_000) then `LBFGS(maxiters=5000)`). The LBFGS stage terminates at **MaxIters**, not at a gradient tolerance — so the reported objective is whatever value the trajectory happens to reach at the iteration cap. That value depends on BLAS/platform floating-point reassociation, so the assertion flips pass/fail across OSes from run to run:

| Run | ubuntu lts | windows lts | macOS lts |
|-----|-----------|-------------|-----------|
| 2026-06-20 | **FAIL** 2.385e-4 | **FAIL** 2.801e-4 | PASS |
| 2026-06-14 | PASS | PASS | **FAIL** 2.705e-4 |

A converged fit lands anywhere in ~`[3.6e-5, 2.8e-4]`, and the old `1.5e-4` bound sits *inside* that jitter band. This is benign cross-platform numerical non-determinism, not a regression — the package's structural/gradient/JET tests all pass and the network does train.

## Verification (local, Julia 1.10 LTS, linux)

- Full `Basic` safetestset (test deps resolved via `[targets].test`): **`10 Pass, 2 Broken, 0 Fail`** (passes locally even with the *old* 1.5e-4 bound).
- Probe of the exact optimization:
  - `DEFAULT_LBFGS res2.objective = 3.583e-5` (retcode `MaxIters`)
  - `Adam-only res.objective = 2.316` (untrained loss is O(1))

So a successful fit is ~4-5 orders of magnitude below the untrained loss, but the *exact* MaxIters value spans ~10x across platforms.

## Fix

Raise the bound `1.5e-4 -> 5e-4` with an explanatory comment. `5e-4` sits safely above the observed jitter band (max observed failing value 2.8e-4, ~1.8x margin) while remaining ~4000x below the untrained O(1) loss, so it still verifies the UDE actually trained without being sensitive to BLAS/platform reassociation. No test is skipped, broken, or silenced; the assertion still fails if training does not occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)