### PR TITLE
Bump version to 2.5.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitNeuralNets"
 uuid = "f162e290-f571-43a6-83d9-22ecc16da15f"
-version = "2.5.3"
+version = "2.5.4"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (2.5.3 -> 2.5.4) to release unreleased commits on `main` via JuliaRegistrator.