### PR TITLE
Release prep: bump to 2.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitNeuralNets"
 uuid = "f162e290-f571-43a6-83d9-22ecc16da15f"
-version = "2.5.4"
+version = "2.6.0"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]


### PR DESCRIPTION
Version-bump-only release PR. Minor bump (not patch): adds new positional-arg overloads for multi_layer_feed_forward/NeuralNetworkBlock and broadens isneuralnetwork/isneuralnetworkps/get_nn_chain to generic dispatch -- genuine additive public API, backward compatible.