### PR TITLE
ci: run downgrade checks on main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- run the downgrade workflow for pushes to the repository's actual default branch, `main`
- leave the existing pull-request trigger and downgrade configuration unchanged

The workflow currently listens for pushes to `master`, so released changes on `main` do not receive the downgrade check.

## Local verification

- exact deployed `julia-downgrade-compat` resolution and build for `group: Core`: passed
- exact locked `GROUP=Core` package tests: 107 passed, 2 pre-existing broken, 0 failed
- repository-wide Runic check: passed
- `actionlint .github/workflows/Downgrade.yml`: passed
- `Project.toml` TOML parse and `git diff --check`: passed
