### PR TITLE
Restore [sources] entry in docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -43,3 +43,6 @@ Statistics = "1"
 SymbolicIndexingInterface = "0.3.15"
 SymbolicRegression = "1"
 Zygote = "0.7"
+
+[sources.ModelingToolkitNeuralNets]
+path = ".."


### PR DESCRIPTION
Follow-up to https://github.com/SciML/ModelingToolkitNeuralNets.jl/pull/142#discussion_r3687591369.

PR #142 removed

```toml
[sources.ModelingToolkitNeuralNets]
path = ".."
```

from `docs/Project.toml`. That was unintentional (as noted in the review thread) — without it the docs build resolves the last registered release of ModelingToolkitNeuralNets from the General registry rather than the working tree, so docs would not reflect in-development changes. This restores the block; `docs/Project.toml` is now byte-identical to its state before #142.

Verified locally:

```
$ julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.status("ModelingToolkitNeuralNets")'
Status `~/ModelingToolkitNeuralNets.jl/docs/Project.toml`
  [f162e290] ModelingToolkitNeuralNets v2.6.0 `..`
```

Please ignore until reviewed by @ChrisRackauckas.