### PR TITLE
test: restore now-supported gradient checks

### DIFF
--- a/test/lotka_volterra.jl
+++ b/test/lotka_volterra.jl
@@ -119,8 +119,8 @@ ps = (prob, get_vars, data, ts, set_x);
 @test all(.!isnan.(∇l1))
 @test !iszero(∇l1)
 
-@test ∇l1 ≈ ∇l2 rtol = 1.0e-4 broken -= true
-@test ∇l1 ≈ ∇l3 broken = true
+@test ∇l1 ≈ ∇l2 rtol = 1.0e-4
+@test ∇l1 ≈ ∇l3
 
 op = OptimizationProblem(of, x0, ps)
 


### PR DESCRIPTION
Raise the minimum `OptimizationOptimJL` test dependency to the first release that provides the current `SciMLBase.ReturnCode` API, and remove two stale `@test_broken` markers that make the minimum-version DowngradeCI job fail on unexpected passes.

DowngradeCI now passes for the Core group:
https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/runs/32034141728/job/95400498217

The regular test matrix currently fails the same two gradient assertions after they are re-enabled, on both the latest and LTS Julia jobs. For example:
- https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/runs/32034142031/job/95404749609
- https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/runs/32034142031/job/95404749655

Those failures are reported explicitly rather than being hidden with a new skip or broken marker. The PR therefore establishes the correct downgrade behavior while leaving the current-stack numerical gradient issue visible for review.

No public API changes and no deprecation path is required.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.