### PR TITLE
Fix docs build: missing Adam import in nnblock.md

### DIFF
--- a/docs/src/nnblock.md
+++ b/docs/src/nnblock.md
@@ -212,6 +212,7 @@ using OptimizationOptimJL
 using LineSearches
 using Statistics
 using SciMLSensitivity
+using OptimizationOptimisers: Adam
 import SciMLLogging
 import Zygote
 


### PR DESCRIPTION
## Summary

Fixes the broken Documentation CI build (see failing run: https://github.com/SciML/ModelingToolkitNeuralNets.jl/actions/runs/32931227423).

**Root cause:** the `potplate` `@example` block in `docs/src/nnblock.md` calls `solve(op, Adam(); ...)` but never imports `Adam`. `OptimizationOptimJL` (for `LBFGS`) and `LineSearches` (for `BackTracking`) are imported, but `OptimizationOptimisers` (which provides `Adam`) is not, even though it's already a listed dependency in `docs/Project.toml` (and used correctly elsewhere in `friction.md` and `symbolic_ude_tutorial.md`). This caused:

```
UndefVarError: `Adam` not defined in `Main.__atexample__named__potplate`
```

which then cascaded into `UndefVarError: new_sol1 not defined` in the two subsequent `@example potplate` blocks (since `new_sol1` is defined later in the same failing block), terminating `makedocs` with `[:example_block]` errors.

**Fix:** add the missing `using OptimizationOptimisers: Adam` import, matching the style already used in `docs/src/friction.md`.

## Test plan

- Extracted and concatenated all `@example potplate` code blocks from `docs/src/nnblock.md` with the fix applied, and ran them directly with `julia --project=docs` (with `maxiters` temporarily reduced for the Adam/LBFGS solves to keep runtime reasonable). The full chain—including the previously-failing `Adam` optimization, the `new_sol1` remake/solve, and the trailing `SymbolicRegression.equation_search` block—now runs to completion with exit code 0 and no `UndefVarError`s.
- Also ran `julia --project=docs -e 'using Pkg; Pkg.instantiate()'` successfully to confirm `docs/Project.toml`/`Manifest.toml` resolve cleanly.
- Did not run the full `docs/make.jl` (`makedocs`) end-to-end locally, since the real (non-reduced) `Adam`/`LBFGS` training + `SymbolicRegression` search in this tutorial alone took ~55 minutes in the CI run; the targeted reproduction above isolates and confirms the actual fix.

Made with [Cursor](https://cursor.com)