### PR TITLE
Add 32-bit All CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,3 +7,10 @@
 [All]
 versions = ["1", "lts"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+["All 32-bit"]
+group = "All"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+


### PR DESCRIPTION

## Summary
- Add a `["All 32-bit"]` matrix-only alias (`group = "All"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `All` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
