### PR TITLE
Remove x86 CI lane (BFloat16s i686)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,10 +7,3 @@
 [All]
 versions = ["1", "lts"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-
-["All 32-bit"]
-group = "All"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
-


### PR DESCRIPTION
## Summary
- Drop the 32-bit CI lane: BFloat16s soft-promote LLVM error on i686 until JuliaMath/BFloat16s#127 ships.
- Matches other SciML lane drops where the platform tooling/package cannot run on i686.

## Test plan
- [ ] Non-x86 CI still green
- [ ] No x86 job in the matrix


Made with [Cursor](https://cursor.com)